### PR TITLE
Improve-map-empty

### DIFF
--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -559,12 +559,6 @@ defmodule Module.Types.DescrTest do
 
       assert union(dynamic(open_map(a: atom())), open_map(a: integer()))
              |> map_fetch(:a) == {false, union(dynamic(atom()), integer())}
-
-      # this is bad
-      assert dynamic() |> map_fetch(:a) == {true, dynamic()}
-      assert union(dynamic(), integer()) |> map_fetch(:a) == {true, dynamic()}
-      assert union(dynamic(open_map(a: integer())), integer()) |> map_fetch(:a) == :badmap
-      assert union(dynamic(integer()), integer()) |> map_fetch(:a) == :badmap
     end
   end
 


### PR DESCRIPTION
the previous algorith was such that, if at one point of the iteration
a certain key is found to be in the wrong place, then we short-circuit
and evaluate the rest of the negations
`map_empty?(...)`
which exists as `or ...` in the code.

But there is another case: when none of those keys are found, and it's just
that the recursive cases were resolved to false. In that case, the map
is _actually_ not empty, and we don't want to compute this recursive call.